### PR TITLE
Depreciation notice on WordPress 5.9.0

### DIFF
--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -208,7 +208,8 @@ function wpcp_get_post_tags() {
  */
 function wpcp_get_authors() {
 	$result = [];
-	$users  = get_users( [ 'who' => 'authors' ] );
+	$users  = get_users( [ 'capability__in' => array('publish_posts') ] );
+	error_log( print_r( $users,true));
 	foreach ( $users as $user ) {
 		$result[ $user->ID ] = "{$user->display_name} ({$user->user_email})";
 	}

--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -209,7 +209,7 @@ function wpcp_get_post_tags() {
 function wpcp_get_authors() {
 	$result = [];
 	$users  = get_users( [ 'capability__in' => array('publish_posts') ] );
-	error_log( print_r( $users,true));
+
 	foreach ( $users as $user ) {
 		$result[ $user->ID ] = "{$user->display_name} ({$user->user_email})";
 	}


### PR DESCRIPTION
Fixed the issue: Deprecated: WP_User_Query was called with an argument that is deprecated since version 5.9.0! who is deprecated. Use capability instead. in /Users/sudiptoshakhari/Site/wpcp-craiglist/wp-includes/functions.php on line 5607