### PR TITLE
Prepare Release v2.0.7

### DIFF
--- a/i18n/languages/wp-content-pilot.pot
+++ b/i18n/languages/wp-content-pilot.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Content Pilot 2.0.6\n"
+"Project-Id-Version: WP Content Pilot 2.0.7\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-02-10 10:55:54+00:00\n"
+"POT-Creation-Date: 2025-02-10 12:20:03+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Logs"
 msgstr ""
 
-#: includes/admin/class-wpcp-admin.php:102 wp-content-pilot.php:255
+#: includes/admin/class-wpcp-admin.php:102 wp-content-pilot.php:280
 msgid "Go Pro"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 
 #: includes/admin/class-wpcp-settings.php:38
 #: includes/admin/views/metabox/spinner-settings.php:10
-#: wp-content-pilot.php:247
+#: wp-content-pilot.php:272
 msgid "Settings"
 msgstr ""
 
@@ -2967,19 +2967,19 @@ msgstr ""
 msgid "Universalizing instances of this class is forbidden."
 msgstr ""
 
-#: wp-content-pilot.php:277
+#: wp-content-pilot.php:302
 msgid "View documentation"
 msgstr ""
 
-#: wp-content-pilot.php:277
+#: wp-content-pilot.php:302
 msgid "Docs"
 msgstr ""
 
-#: wp-content-pilot.php:296
+#: wp-content-pilot.php:321
 msgid "Once a Minute"
 msgstr ""
 
-#: wp-content-pilot.php:322
+#: wp-content-pilot.php:347
 msgid "%1$s in %2$s on line %3$s"
 msgstr ""
 

--- a/i18n/languages/wp-content-pilot.pot
+++ b/i18n/languages/wp-content-pilot.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WP Content Pilot 2.0.6\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-01-15 09:14:06+00:00\n"
+"POT-Creation-Date: 2025-02-10 10:55:54+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Logs"
 msgstr ""
 
-#: includes/admin/class-wpcp-admin.php:102 wp-content-pilot.php:254
+#: includes/admin/class-wpcp-admin.php:102 wp-content-pilot.php:255
 msgid "Go Pro"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 
 #: includes/admin/class-wpcp-settings.php:38
 #: includes/admin/views/metabox/spinner-settings.php:10
-#: wp-content-pilot.php:246
+#: wp-content-pilot.php:247
 msgid "Settings"
 msgstr ""
 
@@ -2959,27 +2959,27 @@ msgstr ""
 msgid "Every %1$d %2$s"
 msgstr ""
 
-#: wp-content-pilot.php:82
+#: wp-content-pilot.php:83
 msgid "Cloning is forbidden."
 msgstr ""
 
-#: wp-content-pilot.php:91
+#: wp-content-pilot.php:92
 msgid "Universalizing instances of this class is forbidden."
 msgstr ""
 
-#: wp-content-pilot.php:276
+#: wp-content-pilot.php:277
 msgid "View documentation"
 msgstr ""
 
-#: wp-content-pilot.php:276
+#: wp-content-pilot.php:277
 msgid "Docs"
 msgstr ""
 
-#: wp-content-pilot.php:295
+#: wp-content-pilot.php:296
 msgid "Once a Minute"
 msgstr ""
 
-#: wp-content-pilot.php:321
+#: wp-content-pilot.php:322
 msgid "%1$s in %2$s on line %3$s"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-content-pilot",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-content-pilot",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "GPL-v2.0-or-later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-content-pilot",
   "title": "WP Content Pilot",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "WP Content Pilot automatically posts contents from various sources based on the predefined keywords.",
   "homepage": "https://pluginever.com",
   "license": "GPL-v2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pluginever,manikmist09
 Tags: autoblog, rss aggregator, news aggregator, rss import, youtube feed, feed import, content curation, feed to post, rss to post, rss feeds, auto post
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 2.0.6
+Stable tag: 2.0.7
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -130,6 +130,9 @@ No, WP Content Pilot does not support multisite WordPress installation.
 We would love to hear your suggestions! Feel free to open a new issue [here](https://github.com/pluginever/wp-content-pilot/issues) as the feature request.
 
 == Changelog ==
+= 2.0.7 (February 10, 2025) =
+* Fix - Few known issues are fixed.
+
 = 2.0.6 (January 15, 2025) =
 * New - Feature to remove cached links if in case needed.
 * Fix - Few known issues fixed.

--- a/wp-content-pilot.php
+++ b/wp-content-pilot.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Content Pilot
  * Plugin URI:        https://wpcontentpilot.com
  * Description:       WP Content Pilot automatically posts contents from various sources based on the predefined keywords.
- * Version:           2.0.6
+ * Version:           2.0.7
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            PluginEver
@@ -47,7 +47,7 @@ final class ContentPilot {
 	 *
 	 * @var string
 	 */
-	protected $version = '2.0.6';
+	protected $version = '2.0.7';
 
 	/**
 	 * The single instance of the class.

--- a/wp-content-pilot.php
+++ b/wp-content-pilot.php
@@ -178,6 +178,31 @@ final class ContentPilot {
 		if ( is_admin() ) {
 			require_once( WPCP_INCLUDES . '/admin/class-wpcp-admin.php' );
 		}
+
+		// Update helper for pro version. This will be removed in the future.
+		if ( defined( 'WPCP_PRO_VERSION' ) ) {
+			add_filter( 'http_request_args', array( $this, 'pro_updater' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Pro Updater.
+	 *
+	 * This is a temporary solution to update the pro version.
+	 * This will be removed in the future.
+	 *
+	 * @param array  $args HTTP request arguments.
+	 * @param string $url Request URL.
+	 *
+	 * @since 2.0.7
+	 * @return array $args HTTP request arguments.
+	 */
+	public function pro_updater( $args, $url ) {
+		if ( str_contains( $url, 'pluginever.com' ) && empty( $args['body']['item_id'] ) && 'wp-content-pilot-pro' === $args['body']['slug'] ) {
+			$args['body']['item_id'] = absint( '59161' );
+		}
+
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
This pull request includes a version update for the WP Content Pilot plugin, along with several related changes to support the new version and fix known issues.

Version update and related changes:

* [`i18n/languages/wp-content-pilot.pot`](diffhunk://#diff-30b1efe290aaebaadfcded3a5a9d4cc06ba80691a0995cf2886b3c4a8d45c7e9L5-R7): Updated the `Project-Id-Version` and `POT-Creation-Date` to reflect the new version 2.0.7.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version number from 2.0.6 to 2.0.7.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6): Updated the stable tag to 2.0.7 and added a changelog entry for the new version. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R133-R135)
* [`wp-content-pilot.php`](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L6-R6): Updated the version number in the plugin header and the `ContentPilot` class. [[1]](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L6-R6) [[2]](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L50-R50)

New feature and bug fixes:

* [`wp-content-pilot.php`](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300R181-R205): Added a temporary pro updater function to support updates for the pro version of the plugin. This function will be removed in the future.Add updates helper