### PR TITLE
Prepare Release v2.0.8

### DIFF
--- a/i18n/languages/wp-content-pilot.pot
+++ b/i18n/languages/wp-content-pilot.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Content Pilot 2.0.7\n"
+"Project-Id-Version: WP Content Pilot 2.0.8\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-02-10 12:20:03+00:00\n"
+"POT-Creation-Date: 2025-02-27 07:39:17+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/includes/admin/views/metabox/advanced-settings.php
+++ b/includes/admin/views/metabox/advanced-settings.php
@@ -43,7 +43,6 @@ echo WPCP_HTML::select_input(
 		'wrapper_class' => 'pro',
 		'options'       => array(
 			''       => esc_html__( 'No Translation', 'wp-content-pilot' ),
-			'yandex' => 'Yandex',
 			'deepl'  => 'deepL',
 		),
 		'attrs'         => array(

--- a/includes/admin/views/metabox/advanced-settings.php
+++ b/includes/admin/views/metabox/advanced-settings.php
@@ -43,6 +43,7 @@ echo WPCP_HTML::select_input(
 		'wrapper_class' => 'pro',
 		'options'       => array(
 			''       => esc_html__( 'No Translation', 'wp-content-pilot' ),
+			// 'yandex' => 'Yandex', // TODO: Remove this option, as it is not used due to the removal of the Yandex API key setting.
 			'deepl'  => 'deepL',
 		),
 		'attrs'         => array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-content-pilot",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-content-pilot",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "GPL-v2.0-or-later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-content-pilot",
   "title": "WP Content Pilot",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "WP Content Pilot automatically posts contents from various sources based on the predefined keywords.",
   "homepage": "https://pluginever.com",
   "license": "GPL-v2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WP Content Pilot - Autoblogging & Affiliate Marketing Plugin ===
 Contributors: pluginever,manikmist09
-Tags: autoblog, rss aggregator, news aggregator, rss import, youtube feed, feed import, content curation, feed to post, rss to post, rss feeds, auto post
+Tags: autoblog, rss aggregator, news aggregator, rss import, youtube feed, rss to post, rss feeds
 Requires at least: 5.0
 Tested up to: 6.7
 Stable tag: 2.0.8

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,9 @@ No, WP Content Pilot does not support multisite WordPress installation.
 We would love to hear your suggestions! Feel free to open a new issue [here](https://github.com/pluginever/wp-content-pilot/issues) as the feature request.
 
 == Changelog ==
+= 2.0.8 (February 27, 2025) =
+* Fix - Few known issues are fixed.
+
 = 2.0.7 (February 10, 2025) =
 * Fix - Few known issues are fixed.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pluginever,manikmist09
 Tags: autoblog, rss aggregator, news aggregator, rss import, youtube feed, feed import, content curation, feed to post, rss to post, rss feeds, auto post
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 2.0.7
+Stable tag: 2.0.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-content-pilot.php
+++ b/wp-content-pilot.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Content Pilot
  * Plugin URI:        https://wpcontentpilot.com
  * Description:       WP Content Pilot automatically posts contents from various sources based on the predefined keywords.
- * Version:           2.0.7
+ * Version:           2.0.8
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            PluginEver

--- a/wp-content-pilot.php
+++ b/wp-content-pilot.php
@@ -47,7 +47,7 @@ final class ContentPilot {
 	 *
 	 * @var string
 	 */
-	protected $version = '2.0.7';
+	protected $version = '2.0.8';
 
 	/**
 	 * The single instance of the class.


### PR DESCRIPTION
This pull request includes several updates to the WP Content Pilot plugin, primarily focused on version updates and minor fixes. The most important changes include updating the version number across various files, removing an unused translation option, and updating the changelog.

Version updates:

* [`i18n/languages/wp-content-pilot.pot`](diffhunk://#diff-30b1efe290aaebaadfcded3a5a9d4cc06ba80691a0995cf2886b3c4a8d45c7e9L5-R7): Updated `Project-Id-Version` to 2.0.8 and `POT-Creation-Date` to February 27, 2025.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version number to 2.0.8.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L3-R6): Updated the stable tag to 2.0.8.
* [`wp-content-pilot.php`](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L6-R6): Updated the version number to 2.0.8 in the plugin header and `ContentPilot` class. [[1]](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L6-R6) [[2]](diffhunk://#diff-9a897b4cf645b5224752395daa2a3aa6b0a4e20a4a6e65a0914d25a64f8ae300L50-R50)

Codebase cleanup:

* [`includes/admin/views/metabox/advanced-settings.php`](diffhunk://#diff-deb1903df2d9c86f639eb2d096255b3f98f241718e8e301cd320121052b89232L46-R46): Commented out the Yandex translation option, as it is no longer used.

Documentation:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R133-R135): Added a new entry for version 2.0.8 in the changelog, mentioning that a few known issues have been fixed.